### PR TITLE
Add List import

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,8 @@ Full example
 
 .. code:: python
 
+    from typing import List
+
     from apistar import App, Route, http, types, validators
     from sqlalchemy import Column, Integer, String
     from sqlalchemy.orm import Session


### PR DESCRIPTION
Missing import in Readme's Full example
```
    def list_puppies(session: Session) -> List[PuppyType]:
NameError: name 'List' is not defined
```