### PR TITLE
Add support for nested transactions

### DIFF
--- a/apistar_sqlalchemy/components.py
+++ b/apistar_sqlalchemy/components.py
@@ -10,13 +10,13 @@ logger = logging.getLogger(__name__)
 
 
 class SQLAlchemySessionComponent(Component):
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, **kwargs) -> None:
         """
         Configure a new database backend.
 
         :param url: SQLAlchemy database url.
         """
-        self.engine = create_engine(url)
+        self.engine = create_engine(url, **kwargs)
         database.Session.configure(bind=self.engine)
         logger.info('SQLAlchemy connection created')
         logger.debug('Engine connection to %s', url)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,8 @@
+from apistar_sqlalchemy import database
+from sqlalchemy import Column, Integer, String
+
+
+class PuppyModel(database.Base):
+    __tablename__ = "Puppy"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    name = Column(String)

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -2,18 +2,13 @@ from typing import List
 
 import pytest
 from apistar import ASyncApp, App, Route, TestClient, http, types, validators
-from sqlalchemy import Column, Integer, String
 from sqlalchemy.orm import Session
 
 from apistar_sqlalchemy import database
 from apistar_sqlalchemy.components import SQLAlchemySessionComponent
 from apistar_sqlalchemy.event_hooks import SQLAlchemyTransactionHook
 
-
-class PuppyModel(database.Base):
-    __tablename__ = "Puppy"
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    name = Column(String)
+from .models import PuppyModel
 
 
 class PuppyType(types.Type):

--- a/tests/test_transaction_hook.py
+++ b/tests/test_transaction_hook.py
@@ -1,0 +1,53 @@
+import pytest
+from apistar import http
+from apistar_sqlalchemy import database
+from apistar_sqlalchemy.event_hooks import SQLAlchemyTransactionHook
+from sqlalchemy import create_engine, event
+
+from .models import PuppyModel
+
+
+@pytest.fixture(scope='function')
+def session():
+    database.Session.remove()
+    engine = create_engine('sqlite://')
+
+    @event.listens_for(engine, 'connect')
+    def do_connect(dbapi_connection, connection_record):
+        # Disable pysqlite's emitting of the BEGIN statement entirely. Also
+        # stops it from emitting COMMIT before any DDL. This issue is fixed in
+        # Python 3.6 but not in Python 3.5. More information about the issue
+        # can be found here: https://bugs.python.org/issue10740
+        dbapi_connection.isolation_level = None
+
+    database.Session.configure(bind=engine)
+    database.Base.metadata.create_all(engine)
+    return database.Session()
+
+
+def test_nested_transaction_on_response(session):
+    hook = SQLAlchemyTransactionHook(nested=True)
+    resp = http.Response(content='test')
+
+    txn = session.begin_nested()
+
+    hook.on_request(session)
+    puppy = PuppyModel()
+    session.add(puppy)
+    hook.on_response(resp, exc=None)
+
+    txn.rollback()
+
+
+def test_nested_transaction_on_error(session):
+    hook = SQLAlchemyTransactionHook(nested=True)
+    resp = http.Response(content='test')
+
+    txn = session.begin_nested()
+
+    hook.on_request(session)
+    puppy = PuppyModel()
+    session.add(puppy)
+    hook.on_error(resp)
+
+    txn.rollback()


### PR DESCRIPTION
Setting the flag `nested=True` on the transaction hook allows nested sqlalchemy transactions. 

Instead of creating and destroying all SQL tables before/after a unit test, it is faster to start a transaction and perform a rollback after the unit test. The problem is that without the `nested=True` flag, the transaction hook will commit the changes in the `on_response` method. When rolling the transaction back, the transaction is already committed and that causes the rollback to fail.

Another problem is that the transaction hook will remove the session, which will commit the started transaction outside of the transaction hook. When setting `nested=True`, it is required that the session is removed during the unit test's `setup_method` using `database.Session.remove()`. Otherwise, sqlalchemy will report a warning about a session scope that is already in use.

**edit:** Appearently, python 3.5 fails with `sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such savepoint: sa_savepoint_2 [SQL: 'RELEASE SAVEPOINT sa_savepoint_2']`. Sqlite in Python 3.5 has a default setting that doesn't work as expected and that setting has been changed in python 3.6: https://docs.python.org/3/library/sqlite3.html#sqlite3-controlling-transactions.

See also the related Python stdlib issue: https://bugs.python.org/issue10740. 